### PR TITLE
fix: C-PR1 — restore voice by shipping the DAVE (E2EE) binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ FROM python:3.13 AS stage
 WORKDIR /GBot
 ENV PYTHONPATH=/GBot
 
+# ffmpeg also supplies libopus, which nextcord resolves at runtime for voice.
+# PyNaCl used to be pip-installed here against apt's libsodium-dev; it is now a pinned
+# entry in requirements.txt and installs from a prebuilt abi3 wheel with libsodium
+# bundled, so neither the apt package nor the source build is needed.
 RUN apt-get update \
     && apt-get install -y openssl \
-    && apt-get install -y ffmpeg \
-    && apt-get install -y libsodium-dev \
-    && SODIUM_INSTALL=system pip3 install pynacl
+    && apt-get install -y ffmpeg
 
 COPY requirements.txt requirements.txt
 RUN pip install --upgrade pip

--- a/GBotDiscord/test/dependencies_test.py
+++ b/GBotDiscord/test/dependencies_test.py
@@ -2,6 +2,8 @@
 import importlib
 import importlib.metadata
 import unittest
+
+from nextcord import voice_client
 #endregion
 
 # Runtime dependency lock tests (HalloweenEvent pattern): every dep pinned in
@@ -9,6 +11,7 @@ import unittest
 
 RUNTIME_DEPENDENCY_MODULES = [
     'audioop',
+    'dave',
     'debugpy',
     'df2img',
     'emoji',
@@ -18,6 +21,7 @@ RUNTIME_DEPENDENCY_MODULES = [
     'nextcord.ext.menus',
     'numpy',
     'pandas',
+    'nacl.secret',
     'quart',
     'quart_cors',
     'yt_dlp',
@@ -56,6 +60,24 @@ class TestDependencies(unittest.TestCase):
         # PYSEC-2026-1860 was fixed in quart 0.20.0; the pin must never regress below it.
         version = tuple(int(part) for part in importlib.metadata.version('quart').split('.'))
         self.assertGreaterEqual(version, (0, 20, 0))
+
+    def test_pynacl_at_or_above_security_floor(self):
+        # PYSEC-2026-3002 was fixed in PyNaCl 1.6.2. nextcord 3.2.0's voice extra declares
+        # PyNaCl<1.6, so the tempting "just honour the library's range" move reintroduces the
+        # advisory; the pin is above the ceiling on purpose and must never regress below it.
+        version = tuple(int(part) for part in importlib.metadata.version('PyNaCl').split('.'))
+        self.assertGreaterEqual(version, (1, 6, 2))
+
+    def test_voiceStack_advertises_dave_protocol(self):
+        # Discord has enforced DAVE (voice E2EE) for all non-stage voice since 2026-03-02 and
+        # refuses connections with close code 4017 unless the client advertises a protocol
+        # version. nextcord builds that number as min(its own ceiling, dave's ceiling) and
+        # returns 0 outright when the binding is absent, so all three facts below have to hold
+        # or /play, /spotify and /elevator are dead in production.
+        self.assertTrue(voice_client.has_nacl, 'PyNaCl is missing: voice transport encryption is unavailable.')
+        self.assertTrue(voice_client.has_dave, 'dave-py is missing: nextcord would advertise max_dave_protocol_version 0.')
+        self.assertGreaterEqual(importlib.import_module('dave').get_max_supported_protocol_version(), 1)
+        self.assertGreaterEqual(voice_client.E2EEState.MAX_SUPPORTED_PROTOCOL_VERSION, 1)
 
     def test_h11_at_or_above_security_floor(self):
         # PYSEC-2026-348 was fixed in h11 0.16.0 (transitive via httpx/httpcore);

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,13 @@
 # at module load, so the maintained backport is required on the python:3.13 image
 audioop-lts==0.2.2; python_version >= "3.13"
 
+# dave-py is nextcord's DAVE (voice E2EE) binding, and it is NOT optional in practice:
+# Discord has enforced DAVE for all non-stage voice since 2026-03-02, and without this
+# module nextcord reports max_dave_protocol_version 0 and every voice connection is
+# refused with close code 4017 (see plans/feature-modernization-roadmap.md, C-2).
+# Declared directly rather than as nextcord[voice], because that extra also pins
+# PyNaCl<1.6 — see the PyNaCl note below.
+dave-py==0.1.2
 debugpy==1.8.21
 df2img==0.2.10
 emoji==2.2.0
@@ -14,6 +21,12 @@ nextcord==3.2.0
 nextcord-ext-menus==1.5.6
 numpy==2.5.1
 pandas==2.3.3
+# PyNaCl encrypts every voice packet (nextcord uses nacl.secret.Aead for the
+# aead_xchacha20_poly1305_rtpsize transport mode). It used to be installed ad hoc in the
+# Dockerfile, which kept it unpinned and invisible to pip-audit. 1.6.2 is deliberately
+# ABOVE nextcord 3.2.0's declared PyNaCl<1.6 ceiling: that ceiling predates
+# PYSEC-2026-3002, whose only fix is 1.6.2, so honouring it would fail the pip-audit gate.
+PyNaCl==1.6.2
 quart==0.21.0
 quart-cors==0.7.0
 yt-dlp==2026.7.4


### PR DESCRIPTION
## What

Every voice feature — `/play`, `/spotify`, `/elevator` — has been **dead in production since 2026-03-02**, when Discord began enforcing [DAVE end-to-end encryption](https://support.discord.com/hc/en-us/articles/38749827197591-A-V-E2EE-Enforcement-for-Non-Stage-Voice-Calls) for all non-stage voice. This is the root cause of ledger entry **C-1**, which was originally misread as a nextcord-vs-voice-gateway version mismatch.

nextcord 3.2.0 implements DAVE in full — voice gateway `v8`, opcodes 21–31, a complete MLS key-package/transition state machine — but gates all of it on a bare `try: import dave` (`voice_client.py:61-68`), and ships that binding in its **`voice` extra**. `requirements.txt` installed `nextcord==3.2.0` *without* the extra, so `has_dave` was `False`, `get_max_dave_protocol_version()` returned `0`, voice IDENTIFY advertised `max_dave_protocol_version: 0`, and Discord closed the socket with **4017**.

Full analysis, verdicts and the C-PR sequence: `plans/feature-modernization-roadmap.md` § Workstream C (ledger rows **C-2**, **C-3**).

## Changes

- **`requirements.txt`** — add `dave-py==0.1.2` and `PyNaCl==1.6.2`, declared **directly rather than via `nextcord[voice]`**: that extra pins `PyNaCl>=1.5.0,<1.6`, and 1.5.0 carries **PYSEC-2026-3002** (fixed only in 1.6.2), so adding the extra would fail the pip-audit-0 gate. This is why the pin sits deliberately *above* nextcord's declared ceiling — the ceiling predates the advisory, and the only nacl API nextcord's voice code touches (`nacl.secret.Aead`, `voice_client.py:548`) is present in 1.6.2.
- **`Dockerfile`** — drop `libsodium-dev` and the ad-hoc `SODIUM_INSTALL=system pip3 install pynacl` (**C-3**). PyNaCl was unpinned and **invisible to pip-audit** there despite encrypting every voice packet, and its version could change on any rebuild. As a real requirement it installs from a prebuilt `abi3` wheel with libsodium bundled, so neither the apt package nor the source build is needed. `ffmpeg` stays — it also supplies libopus. (`plans/python-base-image-bump.md:199` already recorded that the source build was "insurance for a wheel-miss fallback, not the expected path".)
- **`GBotDiscord/test/dependencies_test.py`** — `dave` and `nacl.secret` added to the importable-module lock; a **PyNaCl >= 1.6.2 security floor** so nobody resolves the range conflict by downgrading back into the advisory; and `test_voiceStack_advertises_dave_protocol`, which asserts `has_nacl`, `has_dave`, and both DAVE version ceilings — the three facts that together decide whether voice can connect at all.

## Verification

- Suite **803 passed / 89 subtests**, coverage **100%**, pip-audit **0 known vulnerabilities**. No `GBotDiscord/src` changes.
- **The new guard was verified to fail against the broken state**: uninstalling `dave-py` in an ephemeral container fails both `test_runtimeDependencies_all_importable[dave]` and `test_voiceStack_advertises_dave_protocol` with `dave-py is missing: nextcord would advertise max_dave_protocol_version 0.`
- Feasibility checked on **`linux/aarch64` + CPython 3.13** (the Pi's arch): `dave_py-0.1.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl`, 5 MB, **zero transitive deps, no toolchain**; installing it flips `has_dave` to `True` with `dave.get_max_supported_protocol_version() == 1`.
- Rest of the voice stack confirmed healthy in-image: `libopus.so.0` resolves and `opus._load_default()` → `True`; `ffmpeg` and `ffprobe` both on `PATH`.

## Merge gate

**`/qa` in a real voice channel**, which needs the Pi instance stopped first (maintainer-run). A voice handshake is precisely the surface the test suite cannot cover — the suite can prove the binding is present and advertised, not that Discord accepts the MLS handshake. Please hold merge until that passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)